### PR TITLE
Update OG Image Content

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,7 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="My Philippines Travel Level">
     <meta property="og:description" content="A simple web app to visualize how well-travelled you are in the Philippines">
-    <meta property="og:image" content="/social-preview.jpg">
+    <meta property="og:image" content="https://www.my-philippines-travel-level.com/social-preview.jpg">
 
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
@@ -43,7 +43,7 @@
     <meta property="twitter:url" content="https://my-philippines-travel-level.com">
     <meta name="twitter:title" content="My Philippines Travel Level">
     <meta name="twitter:description" content="A simple web app to visualize how well-travelled you are in the Philippines">
-    <meta name="twitter:image" content="/social-preview.jpg">
+    <meta name="twitter:image" content="https://www.my-philippines-travel-level.com/social-preview.jpg">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Resolve #26 

Fixed the link of OG image content as it is not visible on Twitter.

<details><summary>Click to see changes</summary>
<p>

#### Facebook 
<details><summary>Click to preview</summary>
<p>

![image](https://user-images.githubusercontent.com/26820513/234639054-49a36c0f-06b6-4278-9105-781de6e780fd.png)

</p>
</details> 

#### Twitter

<details><summary>Click to preview</summary>
<p>

![image](https://user-images.githubusercontent.com/26820513/234639120-5875feb0-39d2-4162-a140-580f72248f87.png)

</p>
</details> 

</p>
</details> 