### PR TITLE
🆕 chore(bump_version.yml): add GitHub Action to bump version and push tag

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,18 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
+
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.61.0 # Don't use @master unless you're happy to test the latest version
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true


### PR DESCRIPTION
🆕 chore(bump_version.yml): add GitHub Action to bump version and push tag

This commit adds a new GitHub Action to bump the version and push a tag to the repository. The action is triggered on push events to the master branch. The action uses the anothrNick/github-tag-action@1.61.0 action to bump the version and push the tag. The action is configured to use the GITHUB_TOKEN secret to authenticate with GitHub.