### PR TITLE
fix: redirect broken or unknown URLs to homepage via 404 fallback

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0; url=/" />
+    <script>
+      // Fallback for browsers that don't honor meta refresh
+      window.location.replace('/');
+    </script>
+  </head>
+  <body>
+    <p>Redirecting to homepage...</p>
+  </body>
+</html>


### PR DESCRIPTION
This update adds a custom `404.html` file to gracefully handle unknown or invalid paths when the site is hosted on GitHub Pages. Instead of showing a generic 404 error, users who visit broken or outdated URLs (like /map) will now be redirected to the homepage. This ensures a smoother user experience, prevents confusion, and helps maintain navigation flow even when external links or bookmarks are incorrect.