### PR TITLE
Add support for custom domain and improve SEO

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+my-philippines-travel-level.com

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="A simple web app to visualize how well-travelled you are in the Philippines"
     />
+    <link rel="canonical" href="https://my-philippines-travel-level.com/" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/ph-blank.jpg" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
Summary
This PR improves deployment stability and search engine optimization for the site by:

✅ Adding a CNAME file in the public/ folder to preserve the custom domain (my-philippines-travel-level.com) across deployments.
✅ Adding a <link rel="canonical"> tag in index.html to signal to search engines that the homepage is the official canonical URL, which helps prevent indexing of incorrect or duplicate URLs (e.g. /&).

Why it matters
Ensures that GitHub Pages retains the custom domain after every deploy (fixes issue where it gets reset).
Helps Google index the correct URL, improving search result accuracy and avoiding SEO penalties for duplicate content or bad URLs.
